### PR TITLE
[TT-17030] Migrate remaining workflows from PAT to GitHub App token

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -8,15 +8,25 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       GOPRIVATE: github.com/TykTechnologies
-      GH_ACCESS_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
           stable: 'false'
           go-version: '1.19'
 
-      - run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
+      - name: Configure Git for private modules
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+        run: git config --global url.https://${TOKEN}@github.com/.insteadOf https://github.com/
       - name: Generate  documentation
         run: make generate-docs
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,12 +16,22 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOPRIVATE: github.com/TykTechnologies
-      GH_ACCESS_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
+      - name: Configure Git for private modules
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+        run: git config --global url.https://${TOKEN}@github.com/.insteadOf https://github.com/
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOPRIVATE: github.com/TykTechnologies
-      GH_ACCESS_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -19,7 +26,10 @@ jobs:
         with:
           go-version: '1.19'
 
-      - run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
+      - name: Configure Git for private modules
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+        run: git config --global url.https://${TOKEN}@github.com/.insteadOf https://github.com/
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,24 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       GOPRIVATE: github.com/TykTechnologies
-      GH_ACCESS_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
           stable: 'false'
           go-version: '1.19'
 
-      - run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
+      - name: Configure Git for private modules
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+        run: git config --global url.https://${TOKEN}@github.com/.insteadOf https://github.com/
       - name: Testing
         run: make tests


### PR DESCRIPTION
## Summary
- Replace `ORG_GH_TOKEN` (PAT) with GitHub App token generation using `actions/create-github-app-token` across all 4 workflow files
- Each job now generates its own short-lived GitHub App token as the first step, replacing the long-lived PAT previously set via `GH_ACCESS_TOKEN` env var
- The `GH_ACCESS_TOKEN` env var has been removed; git config now uses the app token output directly

## Files changed
- `.github/workflows/release.yml` — app-token step + token replacement in git config
- `.github/workflows/generate.yml` — app-token step + token replacement in git config
- `.github/workflows/golangci-lint.yml` — app-token step + token replacement in git config
- `.github/workflows/test.yml` — app-token step + token replacement in git config

## Test plan
- [ ] Verify `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` org secrets are available to this repo
- [ ] Trigger a workflow run on a test branch and confirm the GitHub App token is generated successfully
- [ ] Confirm private Go module fetching works with the new token

🤖 Generated with [Claude Code](https://claude.com/claude-code)