### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix for GitHub App tokens

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Configure Git for private modules
         env:
           TOKEN: ${{ steps.app-token.outputs.token }}
-        run: git config --global url.https://${TOKEN}@github.com/.insteadOf https://github.com/
+        run: git config --global url.https://x-access-token:${TOKEN}@github.com/.insteadOf https://github.com/
       - name: Generate  documentation
         run: make generate-docs
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure Git for private modules
         env:
           TOKEN: ${{ steps.app-token.outputs.token }}
-        run: git config --global url.https://${TOKEN}@github.com/.insteadOf https://github.com/
+        run: git config --global url.https://x-access-token:${TOKEN}@github.com/.insteadOf https://github.com/
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Configure Git for private modules
         env:
           TOKEN: ${{ steps.app-token.outputs.token }}
-        run: git config --global url.https://${TOKEN}@github.com/.insteadOf https://github.com/
+        run: git config --global url.https://x-access-token:${TOKEN}@github.com/.insteadOf https://github.com/
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Configure Git for private modules
         env:
           TOKEN: ${{ steps.app-token.outputs.token }}
-        run: git config --global url.https://${TOKEN}@github.com/.insteadOf https://github.com/
+        run: git config --global url.https://x-access-token:${TOKEN}@github.com/.insteadOf https://github.com/
       - name: Testing
         run: make tests


### PR DESCRIPTION
## Summary
- Add `x-access-token:` prefix to the token in the `insteadOf` URL in release.yml (1), generate.yml (1), golangci-lint.yml (1), and test.yml (1)
- The bare token format doesn't work when `actions/checkout` has configured a credential helper; the `x-access-token:` prefix fixes this

## Test plan
- [ ] Verify release workflow can pull private Go modules
- [ ] Verify generate, test, and lint workflows authenticate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)